### PR TITLE
Clear quick filter value when new data comes up to show full list

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "react-components",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "main": "dist/react-components.css",
   "keywords": [
     "react-component"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-components",
-    "version": "0.4.0",
+    "version": "0.4.1",
     "keywords": [
         "react-component"
     ],

--- a/src/js/table/TableStore.js
+++ b/src/js/table/TableStore.js
@@ -77,6 +77,9 @@ define(function(require) {
             }, this);
 
             this.selectedItems = {};
+            //Reset the filter value on data change to clear any filtered state. Anytime new data comes in we want to clear all quick filters
+            //that might applied and show the full result set.
+            this.filterValue = null;
 
             if (typeof this.sortColIndex === 'number') {
                 this.sortData(this.sortColIndex, this.cols[this.sortColIndex].sortDirection);

--- a/src/js/table/tests/TableStore.test.js
+++ b/src/js/table/tests/TableStore.test.js
@@ -112,6 +112,15 @@ define(function(require) {
                     expect(table.selectedItems).toEqual({});
                 });
 
+                it('should reset quick filter data', function(){
+                    spyOn(table, 'sortData');
+                    expect(table.data).toBeNull();
+                    table.filterValue = 'abc';
+                    table.onDataReceived(data);
+                    expect(table.data).not.toBeNull();
+                    expect(table.filterValue).toBeNull();
+                });
+
                 describe('percent formatter', function() {
                     it('should correctly format a percent dataType', function() {
                         table.onDataReceived(definition.data);


### PR DESCRIPTION
If a user types a value into the quick filter, and then causes new data to come in (via some other source), the quick filter wasn't getting cleared and so the data coming in might be missing. This was compounded by the fact that the value in the quick filter text box was clearing, but the filter value was not.