### PR TITLE
Handle null/undefined fields when sorting and searching

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ $ npm install -g react-tools
 
 ```
 $ cd ~/path/to/react-components/root
+$ npm install
 $ grunt init
 ```
 

--- a/src/js/examples/utils/RequestHandler.js
+++ b/src/js/examples/utils/RequestHandler.js
@@ -11,11 +11,13 @@ define(function(require) {
         {"spacecraft": "ISS", "archived": true, "name": "Aryabhata", "mission": 'Test satellite (India)', "launched": 1, "lastLaunchDate": 167097600000, "lastCommunication": 167529600000},
         {"spacecraft": "SEO", "archived": true, "name": "Bhaskara", "mission": 'Earth observing sat (India)', "launched": 1, "lastLaunchDate": 297561600000, "lastCommunication": 624585602301},
         {"spacecraft": "STARS-2", "name": "Kukai", "mission": 'Tether experiment', "launched": 2, "lastLaunchDate": 1393459200000, "lastCommunication": moment().subtract(2, 'minutes').valueOf()},
+        {"spacecraft": "SS Missing Data", "name": null,  "mission": undefined, "launched": undefined, "lastLaunchDate": null, "lastCommunication": undefined},
         {"spacecraft": "Sina", "name": "Sina(h)-1", "mission": 'Test satellite', "launched": 1, "lastLaunchDate": 1130371200000, "lastCommunication": 1145577603301},
         {"spacecraft": "Ghauri", "name": "Ghauri", "mission": 'Missile', "launched": 2, "lastLaunchDate": 924048000000},
         {"spacecraft": "Marcopolo", "name": "Marcopolo", "mission": 'Communications sat, England', "launched": 2, "lastLaunchDate": 650937600000, "lastCommunication": 104353920521},
         {"spacecraft": "Giotto", "deleted": true, "name": "Giotto", "mission": 'Comet probe (ESA)', "launched": 1, "lastLaunchDate": 489110400000, "lastCommunication": 711849600040},
         {"spacecraft": "MPLM-3", "archived": true, "name": "Donatello", "mission": 'Space station module, not flown', "launched": 0},
+        {"spacecraft": "Prometheus No Data", "name": undefined,  "mission": null, "launched": null, "lastLaunchDate": undefined, "lastCommunication": null},
         {"spacecraft": "XMM", "name": "XMM-Newton", "mission": 'X-ray astronomy', "launched": 1, "lastLaunchDate": 962409610000, "lastCommunication": moment().subtract(1, 'second').valueOf()}
     ];
 

--- a/src/js/examples/utils/RequestHandler.js
+++ b/src/js/examples/utils/RequestHandler.js
@@ -11,13 +11,13 @@ define(function(require) {
         {"spacecraft": "ISS", "archived": true, "name": "Aryabhata", "mission": 'Test satellite (India)', "launched": 1, "lastLaunchDate": 167097600000, "lastCommunication": 167529600000},
         {"spacecraft": "SEO", "archived": true, "name": "Bhaskara", "mission": 'Earth observing sat (India)', "launched": 1, "lastLaunchDate": 297561600000, "lastCommunication": 624585602301},
         {"spacecraft": "STARS-2", "name": "Kukai", "mission": 'Tether experiment', "launched": 2, "lastLaunchDate": 1393459200000, "lastCommunication": moment().subtract(2, 'minutes').valueOf()},
-        {"spacecraft": "SS Missing Data", "name": null,  "mission": undefined, "launched": undefined, "lastLaunchDate": null, "lastCommunication": undefined},
+        {"spacecraft": "SS Missing Data", "name": null, "mission": undefined, "launched": undefined, "lastLaunchDate": null, "lastCommunication": undefined},
         {"spacecraft": "Sina", "name": "Sina(h)-1", "mission": 'Test satellite', "launched": 1, "lastLaunchDate": 1130371200000, "lastCommunication": 1145577603301},
         {"spacecraft": "Ghauri", "name": "Ghauri", "mission": 'Missile', "launched": 2, "lastLaunchDate": 924048000000},
         {"spacecraft": "Marcopolo", "name": "Marcopolo", "mission": 'Communications sat, England', "launched": 2, "lastLaunchDate": 650937600000, "lastCommunication": 104353920521},
         {"spacecraft": "Giotto", "deleted": true, "name": "Giotto", "mission": 'Comet probe (ESA)', "launched": 1, "lastLaunchDate": 489110400000, "lastCommunication": 711849600040},
         {"spacecraft": "MPLM-3", "archived": true, "name": "Donatello", "mission": 'Space station module, not flown', "launched": 0},
-        {"spacecraft": "Prometheus No Data", "name": undefined,  "mission": null, "launched": null, "lastLaunchDate": undefined, "lastCommunication": null},
+        {"spacecraft": "Prometheus No Data", "name": undefined, "mission": null, "launched": null, "lastLaunchDate": undefined, "lastCommunication": null},
         {"spacecraft": "XMM", "name": "XMM-Newton", "mission": 'X-ray astronomy', "launched": 1, "lastLaunchDate": 962409610000, "lastCommunication": moment().subtract(1, 'second').valueOf()}
     ];
 

--- a/src/js/table/TableStore.js
+++ b/src/js/table/TableStore.js
@@ -312,10 +312,10 @@ define(function(require) {
                     if (second === null || second === undefined) {
                         return 0;
                     }
-                    return defaultDirection.valueOf() === direction.valueOf() ? 1 : -1;
+                    return defaultDirection === direction ? 1 : -1;
                 }
                 if (second === null || second === undefined) {
-                    return defaultDirection.valueOf() === direction.valueOf() ? -1 : 1;
+                    return defaultDirection === direction ? -1 : 1;
                 }
 
                 if (dataType === 'string') {

--- a/src/js/table/TableStore.js
+++ b/src/js/table/TableStore.js
@@ -308,14 +308,19 @@ define(function(require) {
 
                 // undefined/null values are sorted to the end of the table when the sort direction is equal to the default
                 // sort direction, and to the top of the table when the sort direction is opposite of default
-                if (!first) {
-                    if (!second) {
+                if (first === null || first === undefined) {
+                    if (second === null || second === undefined) {
                         return 0;
                     }
                     return defaultDirection.valueOf() === direction.valueOf() ? 1 : -1;
                 }
-                if (!second) {
+                if (second === null || second === undefined) {
                     return defaultDirection.valueOf() === direction.valueOf() ? -1 : 1;
+                }
+
+                if (dataType === 'string') {
+                    first = first.toLowerCase();
+                    second = second.toLowerCase();
                 }
 
                 if (first > second) {

--- a/src/js/table/tests/TableStore.test.js
+++ b/src/js/table/tests/TableStore.test.js
@@ -62,7 +62,9 @@ define(function(require) {
                 {string: 'b', integer: 3, mixedCase: 'B', percent: 14},
                 {string: 'a', integer: 0, mixedCase: 'a', time: 1416591981, percent: 43, status: 1416591981},
                 {string: 'aa', integer: 2, mixedCase: 'Aa', time: 1417715098, percent: 78, status: 1417715098},
+                {string: null, integer: null, mixedCase: null, time: null, percent: null, status: null},
                 {string: 'aab', integer: -1, mixedCase: 'aAb', percent: 13},
+                {},
                 {string: 'ab', integer: 1, mixedCase: 'aB', percent: 76},
                 {string: 'aba', integer: 1, mixedCase: 'aBA', time: 1406479597, percent: 99, status: 1406479597}
             ];
@@ -417,7 +419,7 @@ define(function(require) {
                     definition.cols[1].quickFilter = true;
 
                     table.onDataReceived(definition.data);
-                    expect(table.data.length).toEqual(7);
+                    expect(table.data.length).toEqual(9);
                 });
 
                 it('should filter data for each column that has quickFilter set to true and set the dataCount', function() {
@@ -541,7 +543,7 @@ define(function(require) {
                         {
                             dataProperty: 'time',
                             dataType: 'time',
-                            sortDirection: 'ascending'
+                            sortDirection: 'descending'
                         }
                     ];
                     table.data = [
@@ -549,8 +551,10 @@ define(function(require) {
                         {string: 'b', integer: 3, mixedCase: 'B'},
                         {string: 'a', integer: 0, mixedCase: 'a', time: 1416591981},
                         {string: 'aa', integer: 2, mixedCase: 'Aa', time: 1417715098},
+                        {},
                         {string: 'aab', integer: -1, mixedCase: 'aAb'},
                         {string: 'ab', integer: 1, mixedCase: 'aB'},
+                        {string: null, integer: null, mixedCase: null, time: null},
                         {string: 'aba', integer: 1, mixedCase: 'aBA', time: 1406479597}
                     ];
                     table.onDataReceived(table.data);
@@ -585,17 +589,21 @@ define(function(require) {
 
                 it('should sort objects on a key of type integer in ascending order', function() {
                     table.sortData(1, 'ascending');
-                    expect(table.data[0].integer).toEqual(-2);
-                    expect(table.data[1].integer).toEqual(-1);
-                    expect(table.data[2].integer).toEqual(0);
-                    expect(table.data[3].integer).toEqual(1);
-                    expect(table.data[4].integer).toEqual(1);
-                    expect(table.data[5].integer).toEqual(2);
-                    expect(table.data[6].integer).toEqual(3);
+                    // null values will be first because sorting to opposite of default sort order
+                    expect(table.data[0].integer).toBeUndefined();
+                    expect(table.data[1].integer).toBeNull();
+                    expect(table.data[2].integer).toEqual(-2);
+                    expect(table.data[3].integer).toEqual(-1);
+                    expect(table.data[4].integer).toEqual(0);
+                    expect(table.data[5].integer).toEqual(1);
+                    expect(table.data[6].integer).toEqual(1);
+                    expect(table.data[7].integer).toEqual(2);
+                    expect(table.data[8].integer).toEqual(3);
                 });
 
                 it('should sort objects on a key of type integer in descending order', function() {
                     table.sortData(1, 'descending');
+                    // null values will be last because sorting to same as default sort order
                     expect(table.data[0].integer).toEqual(3);
                     expect(table.data[1].integer).toEqual(2);
                     expect(table.data[2].integer).toEqual(1);
@@ -603,10 +611,13 @@ define(function(require) {
                     expect(table.data[4].integer).toEqual(0);
                     expect(table.data[5].integer).toEqual(-1);
                     expect(table.data[6].integer).toEqual(-2);
+                    expect(table.data[7].integer).toBeUndefined();
+                    expect(table.data[8].integer).toBeNull();
                 });
 
                 it('should sort objects on a key of type strings in ascending order', function() {
                     table.sortData(0, 'ascending');
+                    // null values will be last because sorting to same as default sort order
                     expect(table.data[0].string).toEqual('a');
                     expect(table.data[1].string).toEqual('aa');
                     expect(table.data[2].string).toEqual('aaa');
@@ -614,21 +625,27 @@ define(function(require) {
                     expect(table.data[4].string).toEqual('ab');
                     expect(table.data[5].string).toEqual('aba');
                     expect(table.data[6].string).toEqual('b');
+                    expect(table.data[7].string).toBeUndefined();
+                    expect(table.data[8].string).toBeNull();
                 });
 
                 it('should sort objects on a key of type strings in descending order', function() {
                     table.sortData(0, 'descending');
-                    expect(table.data[0].string).toEqual('b');
-                    expect(table.data[1].string).toEqual('aba');
-                    expect(table.data[2].string).toEqual('ab');
-                    expect(table.data[3].string).toEqual('aab');
-                    expect(table.data[4].string).toEqual('aaa');
-                    expect(table.data[5].string).toEqual('aa');
-                    expect(table.data[6].string).toEqual('a');
+                    // null values will be first because sorting to opposite of default sort order
+                    expect(table.data[0].string).toBeUndefined();
+                    expect(table.data[1].string).toBeNull();
+                    expect(table.data[2].string).toEqual('b');
+                    expect(table.data[3].string).toEqual('aba');
+                    expect(table.data[4].string).toEqual('ab');
+                    expect(table.data[5].string).toEqual('aab');
+                    expect(table.data[6].string).toEqual('aaa');
+                    expect(table.data[7].string).toEqual('aa');
+                    expect(table.data[8].string).toEqual('a');
                 });
 
                 it('should sort objects on a key with mixed case strings in a case insensitive manner and in ascending order', function() {
                     table.sortData(2, 'ascending');
+                    // null values will be last because sorting to same as default sort order
                     expect(table.data[0].mixedCase).toEqual('a');
                     expect(table.data[1].mixedCase).toEqual('Aa');
                     expect(table.data[2].mixedCase).toEqual('Aaa');
@@ -636,32 +653,41 @@ define(function(require) {
                     expect(table.data[4].mixedCase).toEqual('aB');
                     expect(table.data[5].mixedCase).toEqual('aBA');
                     expect(table.data[6].mixedCase).toEqual('B');
+                    expect(table.data[7].string).toBeUndefined();
+                    expect(table.data[8].string).toBeNull();
                 });
 
                 it('should sort objects on a key with mixed case strings in a case insensitive manner and in descending order', function() {
                     table.sortData(2, 'descending');
-                    expect(table.data[0].mixedCase).toEqual('B');
-                    expect(table.data[1].mixedCase).toEqual('aBA');
-                    expect(table.data[2].mixedCase).toEqual('aB');
-                    expect(table.data[3].mixedCase).toEqual('aAb');
-                    expect(table.data[4].mixedCase).toEqual('Aaa');
-                    expect(table.data[5].mixedCase).toEqual('Aa');
-                    expect(table.data[6].mixedCase).toEqual('a');
+                    // null values will be first because sorting to opposite of default sort order
+                    expect(table.data[0].string).toBeUndefined();
+                    expect(table.data[1].string).toBeNull();
+                    expect(table.data[2].mixedCase).toEqual('B');
+                    expect(table.data[3].mixedCase).toEqual('aBA');
+                    expect(table.data[4].mixedCase).toEqual('aB');
+                    expect(table.data[5].mixedCase).toEqual('aAb');
+                    expect(table.data[6].mixedCase).toEqual('Aaa');
+                    expect(table.data[7].mixedCase).toEqual('Aa');
+                    expect(table.data[8].mixedCase).toEqual('a');
                 });
 
-                it('should sort objects on a key with timestamps in ascending order if some timestamps are undefined', function() {
+                it('should sort objects on a key of type timestamps in ascending order', function() {
                     table.sortData(3, 'ascending');
+                    // null values will be first because sorting to opposite of default sort order
                     expect(table.data[0].timeTimestamp).toBeNull();
                     expect(table.data[1].timeTimestamp).toBeNull();
                     expect(table.data[2].timeTimestamp).toBeNull();
-                    expect(table.data[3].timeTimestamp).toEqual(1406479597);
-                    expect(table.data[4].timeTimestamp).toEqual(1416591981);
-                    expect(table.data[5].timeTimestamp).toEqual(1417455952);
-                    expect(table.data[6].timeTimestamp).toEqual(1417715098);
+                    expect(table.data[3].timeTimestamp).toBeNull();
+                    expect(table.data[4].timeTimestamp).toBeNull();
+                    expect(table.data[5].timeTimestamp).toEqual(1406479597);
+                    expect(table.data[6].timeTimestamp).toEqual(1416591981);
+                    expect(table.data[7].timeTimestamp).toEqual(1417455952);
+                    expect(table.data[8].timeTimestamp).toEqual(1417715098);
                 });
 
-                it('should sort objects on a key with timestamps in descending order if some timestamps are undefined', function() {
+                it('should sort objects on a key of type timestamps in descending order', function() {
                     table.sortData(3, 'descending');
+                    // null values will be last because sorting to same as default sort order
                     expect(table.data[0].timeTimestamp).toEqual(1417715098);
                     expect(table.data[1].timeTimestamp).toEqual(1417455952);
                     expect(table.data[2].timeTimestamp).toEqual(1416591981);
@@ -669,20 +695,8 @@ define(function(require) {
                     expect(table.data[4].timeTimestamp).toBeNull();
                     expect(table.data[5].timeTimestamp).toBeNull();
                     expect(table.data[6].timeTimestamp).toBeNull();
-                });
-
-                it('should handle string type fields that are undefined', function(){
-                    table.data[0].string = undefined;
-                    table.data[3].string = null;
-
-                    table.sortData(0, 'ascending');
-                    expect(table.data[0].string).toBeUndefined();
-                    expect(table.data[1].string).toBeNull();
-                    expect(table.data[2].string).toEqual('aa');
-                    expect(table.data[3].string).toEqual('aaa');
-                    expect(table.data[4].string).toEqual('ab');
-                    expect(table.data[5].string).toEqual('aba');
-                    expect(table.data[6].string).toEqual('b');
+                    expect(table.data[7].timeTimestamp).toBeNull();
+                    expect(table.data[8].timeTimestamp).toBeNull();
                 });
             });
 


### PR DESCRIPTION
Problem: Null/undefined fields were causing quickSearch to fail.
Solution: Check for null before trying to convert to string

Problem: Null/undefined fields were sorting to the top of the table when sorting a column by its default sort order.
Solution: Have null/undefined fields sort to the bottom of the table when a column is being sorted by its default sort order.  When sorting by the non-default sort order, have the null/undefined fields sort to the top of the table.  (Fixes #26)