### PR TITLE
Advanced filter changes: Namespace input ids, Place input before label

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Dataminr",
   "name": "dataminr-react-components",
   "description": "Collection of reusable React Components and utility functions",
-  "version": "0.5.5",
+  "version": "0.6.0",
   "keywords": [
     "react-component"
   ],

--- a/src/js/table/BaseTable.js
+++ b/src/js/table/BaseTable.js
@@ -177,11 +177,12 @@ module.exports = {
      * @returns {ReactElement} - A React div element containing an advanced filter item.
      */
     getAdvancedFilterItemMarkup: function(filter, index) {
-        var filterId = `filter-${this.props.componentId}-${index}`;
         return (
             <div key={index} className="advanced-filter-item">
-                <input id={filterId} type="checkbox" checked={filter.checked || false} onChange={this.handleAdvancedFilterToggle.bind(this, filter)} />
-                <label htmlFor={filterId} className="no-select">{filter.label}</label>
+                <label className="no-select">
+                    {filter.label}
+                    <input type="checkbox" checked={filter.checked || false} onChange={this.handleAdvancedFilterToggle.bind(this, filter)} />
+                </label>
             </div>
         );
     },

--- a/src/js/table/BaseTable.js
+++ b/src/js/table/BaseTable.js
@@ -179,8 +179,8 @@ module.exports = {
     getAdvancedFilterItemMarkup: function(filter, index) {
         return (
             <div key={index} className="advanced-filter-item">
-                <label htmlFor={`filter-${index}`} className="no-select">{filter.label}</label>
                 <input id={`filter-${index}`} type="checkbox" checked={filter.checked || false} onChange={this.handleAdvancedFilterToggle.bind(this, filter)} />
+                <label htmlFor={`filter-${index}`} className="no-select">{filter.label}</label>
             </div>
         );
     },

--- a/src/js/table/BaseTable.js
+++ b/src/js/table/BaseTable.js
@@ -229,7 +229,7 @@ module.exports = {
                 {cursor}
                 <span>-</span>
                 {lastDisplayedVal}
-                <span>&nbsp; of &nbsp;</span>
+                <span>&nbsp;of&nbsp;</span>
                 {this.state.dataCount}
                 <i className={leftControl + ' ' + this.iconClasses.pageLeft} onClick={handlePageLeftClick} />
                 <i className={rightControl + ' ' + this.iconClasses.pageRight} onClick={handlePageRightClick} />

--- a/src/js/table/BaseTable.js
+++ b/src/js/table/BaseTable.js
@@ -177,10 +177,11 @@ module.exports = {
      * @returns {ReactElement} - A React div element containing an advanced filter item.
      */
     getAdvancedFilterItemMarkup: function(filter, index) {
+        var filterId = `filter-${this.props.componentId}-${index}`;
         return (
             <div key={index} className="advanced-filter-item">
-                <input id={`filter-${index}`} type="checkbox" checked={filter.checked || false} onChange={this.handleAdvancedFilterToggle.bind(this, filter)} />
-                <label htmlFor={`filter-${index}`} className="no-select">{filter.label}</label>
+                <input id={filterId} type="checkbox" checked={filter.checked || false} onChange={this.handleAdvancedFilterToggle.bind(this, filter)} />
+                <label htmlFor={filterId} className="no-select">{filter.label}</label>
             </div>
         );
     },

--- a/src/js/table/tests/BasicTable.test.js
+++ b/src/js/table/tests/BasicTable.test.js
@@ -330,11 +330,14 @@ describe('Table', function() {
             var markup = table.getAdvancedFilterItemMarkup(table.state.advancedFilters[0]);
 
             expect(markup.props.className).toEqual('advanced-filter-item');
-            expect(markup.props.children[0].type).toEqual('input');
-            expect(markup.props.children[0].props.type).toEqual('checkbox');
-            expect(markup.props.children[0].props.checked).toEqual(false);
-            expect(markup.props.children[1].props.children).toEqual('Show Archived');
 
+            var label = markup.props.children;
+            expect(label.type).toEqual('label');
+            expect(label.props.children[0]).toEqual('Show Archived');
+
+            expect(label.props.children[1].type).toEqual('input');
+            expect(label.props.children[1].props.type).toEqual('checkbox');
+            expect(label.props.children[1].props.checked).toEqual(false);
         });
     });
 

--- a/src/js/table/tests/BasicTable.test.js
+++ b/src/js/table/tests/BasicTable.test.js
@@ -330,10 +330,11 @@ describe('Table', function() {
             var markup = table.getAdvancedFilterItemMarkup(table.state.advancedFilters[0]);
 
             expect(markup.props.className).toEqual('advanced-filter-item');
-            expect(markup.props.children[0].props.children).toEqual('Show Archived');
-            expect(markup.props.children[1].type).toEqual('input');
-            expect(markup.props.children[1].props.type).toEqual('checkbox');
-            expect(markup.props.children[1].props.checked).toEqual(false);
+            expect(markup.props.children[0].type).toEqual('input');
+            expect(markup.props.children[0].props.type).toEqual('checkbox');
+            expect(markup.props.children[0].props.checked).toEqual(false);
+            expect(markup.props.children[1].props.children).toEqual('Show Archived');
+
         });
     });
 

--- a/src/sass/_table.scss
+++ b/src/sass/_table.scss
@@ -1,16 +1,21 @@
 @import 'vars';
 
 .table-component {
-  .advanced-filter-item {
-    display: inline-block;
-    margin: 3px 5px;
+  .advanced-filters {
+    display: flex;
 
-    span {
-      margin: 0 5px;
-    }
+    .advanced-filter-item {
+      display: flex;
+      flex-direction: row-reverse;
+      margin: 3px 5px;
 
-    input {
-      margin: 0 3px;
+      label {
+        margin: 0 5px;
+      }
+
+      input {
+        margin: 5px 3px 0 0;
+      }
     }
   }
 

--- a/src/sass/_table.scss
+++ b/src/sass/_table.scss
@@ -5,16 +5,13 @@
     display: flex;
 
     .advanced-filter-item {
+      align-items: center;
       display: flex;
       flex-direction: row-reverse;
-      margin: 3px 5px;
+      margin: 3px 7px;
 
       label {
-        margin: 0 5px;
-      }
-
-      input {
-        margin: 5px 3px 0 0;
+        margin-right: 4px;
       }
     }
   }

--- a/src/sass/_table.scss
+++ b/src/sass/_table.scss
@@ -1,18 +1,12 @@
 @import 'vars';
 
 .table-component {
-  .advanced-filters {
-    display: flex;
+  .advanced-filter-item {
+    display: inline-block;
+    margin: 3px 5px;
 
-    .advanced-filter-item {
-      align-items: center;
-      display: flex;
-      flex-direction: row-reverse;
-      margin: 3px 7px;
-
-      label {
-        margin-right: 4px;
-      }
+    input {
+      margin: 0 3px;
     }
   }
 


### PR DESCRIPTION
Associate the input to the label implicityly
- There was an issue when trying to place multiple tables on a single page where clicking a label would toggle the wrong checkbox. This fixes the problem.