### PR TITLE
Fix table header width bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Dataminr",
   "name": "dataminr-react-components",
   "description": "Collection of reusable React Components and utility functions",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "keywords": [
     "react-component"
   ],

--- a/src/js/table/BaseTable.js
+++ b/src/js/table/BaseTable.js
@@ -318,7 +318,8 @@ module.exports = {
                 title={colData.headerLabel}
                 key={`th-${index}`}
                 style={{width: colData.width}}
-                onClick={onClick}>{colData.headerLabel}
+                onClick={onClick}>
+                <span>{colData.headerLabel}</span>
                 {icon}
             </th>
         );


### PR DESCRIPTION
Wrap header label in span so css rules can still target it as they did before the React 15 upgrade.  (React no longer wraps stand-alone text in spans.)