### PR TITLE
Expanded table action column callback params

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Dataminr",
   "name": "dataminr-react-components",
   "description": "Collection of reusable React Components and utility functions",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "keywords": [
     "react-component"
   ],

--- a/src/js/table/BaseTable.js
+++ b/src/js/table/BaseTable.js
@@ -405,8 +405,9 @@ module.exports = {
                 evt.stopPropagation();
                 var row = evt.currentTarget.parentNode;
                 // The row index is off by one due to the table row that wraps the table header items.
-                var rowData = this.state.data[row.rowIndex - 1];
-                meta.onClick(evt, rowData);
+                var rowIdx = row.rowIndex - 1;
+                var rowData = this.state.data[rowIdx];
+                meta.onClick(evt, rowData, this.props, this.state, rowIdx);
             }, this);
             return <td className="action-column-td no-select" onClick={clickWrapper} key={'td-' + index}>{meta.markup}</td>;
         }

--- a/src/js/table/tests/BasicTable.test.js
+++ b/src/js/table/tests/BasicTable.test.js
@@ -802,7 +802,7 @@ describe('Table', function() {
             expect(cell.props.onClick).toBeFunction();
             cell.props.onClick(event);
             expect(event.stopPropagation).toHaveBeenCalled();
-            expect(rowMeta.onClick).toHaveBeenCalledWith(event, tableData[2]);
+            expect(rowMeta.onClick).toHaveBeenCalledWith(event, tableData[2], table.props, table.state, 2);
         });
     });
 


### PR DESCRIPTION
Added props, state, and row click index to the params of the callback execution for table action columns.

@ernieturner 
@jvswatson 
@Keara-Haley 