### PR TITLE
Handle pagination

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Dataminr",
   "name": "dataminr-react-components",
   "description": "Collection of reusable React Components and utility functions",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "keywords": [
     "react-component"
   ],

--- a/src/js/table/Table.js
+++ b/src/js/table/Table.js
@@ -89,7 +89,7 @@ module.exports = createReactClass({
     componentWillReceiveProps() {
         var table = TableStore.getInstance(this.props.componentId);
         if(table.getDataCount()) {
-            table.onDataReceived(table.getData());
+            table.onDataReceived(table.data);
         }
     },
 

--- a/src/js/table/tests/Table.test.js
+++ b/src/js/table/tests/Table.test.js
@@ -204,7 +204,6 @@ describe('Table', function() {
             var tableInstance = TableStore.getInstance(id);
             spyOn(tableInstance, 'getDataCount').and.returnValue({data: 'data'});
             spyOn(tableInstance, 'onDataReceived').and.callFake(function() {return;});
-            spyOn(tableInstance, 'getData').and.callFake(function() {return;});
             table.componentWillReceiveProps();
             expect(tableInstance.onDataReceived.calls.count()).toEqual(1);
         });


### PR DESCRIPTION
We should use `table.data` instead of `table.getData()` in componentWillReceiveProps because getData() will return the displayData and not the full set of table data. This becomes an issue when we have pagination. 