### PR TITLE
Cancel outstanding requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Dataminr",
   "name": "dataminr-react-components",
   "description": "Collection of reusable React Components and utility functions",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "keywords": [
     "react-component"
   ],

--- a/src/js/search/Search.js
+++ b/src/js/search/Search.js
@@ -157,9 +157,7 @@ var Search = createReactClass({
             this.outstandingRequest = RequestHandler.request(
                 this.props.url,
                 this.getSearchFilters(searchTerm),
-                function(data) {
-                    return this.onDataReceived(data, searchTerm);
-                },
+                function(data) {return this.onDataReceived(data, searchTerm);},
                 this.onError,
                 this
             );

--- a/src/js/search/Search.js
+++ b/src/js/search/Search.js
@@ -144,23 +144,26 @@ var Search = createReactClass({
      * @param {String} searchTerm Term searched on
      */
     requestDataForTerm: function(searchTerm){
-        var cachedData = this.cache[this.getSearchTermCacheKey(searchTerm)];
-
-        if(cachedData){
-            this.updateStateForNewData(cachedData);
-            return;
-        }
-
         //Cancel any existing requests
         if(this.outstandingRequest && this.outstandingRequest.abort){
             this.outstandingRequest.abort();
         }
 
-        var onSuccess = function(data) {
-            return this.onDataReceived(data, searchTerm);
-        };
-
-        this.outstandingRequest = RequestHandler.request(this.props.url, this.getSearchFilters(searchTerm), onSuccess, this.onError, this);
+        var cachedData = this.cache[this.getSearchTermCacheKey(searchTerm)];
+        if(cachedData){
+            this.updateStateForNewData(cachedData);
+        }
+        else {
+            this.outstandingRequest = RequestHandler.request(
+                this.props.url,
+                this.getSearchFilters(searchTerm),
+                function(data) {
+                    return this.onDataReceived(data, searchTerm);
+                },
+                this.onError,
+                this
+            );
+        }
     },
 
     /**


### PR DESCRIPTION
Historically, previous 'requests for term' were only cancelled if the current request was _not_ coming from cache. This can cause a previous keystroke to overwrite the results of a current keystroke/search that was retrieved from the cache. 