### PR TITLE
formatting a string with moment is allowed

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Dataminr",
   "name": "dataminr-react-components",
   "description": "Collection of reusable React Components and utility functions",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "keywords": [
     "react-component"
   ],

--- a/src/js/table/TableStore.js
+++ b/src/js/table/TableStore.js
@@ -67,7 +67,7 @@ Table.prototype = {
 
             item[col.dataProperty] = item[col.dataProperty] || null;
             // Provide formatted value in different field.
-            item[`${col.dataProperty}Timestamp`] = item[col.dataProperty] && typeof item[col.dataProperty] !== 'string'
+            item[`${col.dataProperty}Timestamp`] = item[col.dataProperty]
                 ? (typeof col.timeFormat === 'function' ? col.timeFormat(item[col.dataProperty]) : moment(item[col.dataProperty]).format(col.timeFormat))
                 : '--';
         };

--- a/src/js/table/tests/TableStore.test.js
+++ b/src/js/table/tests/TableStore.test.js
@@ -171,6 +171,16 @@ describe('TableStore', function() {
                     expect(table.data[6].timeTimestamp).toEqual('--');
                     expect(table.data[6].statusTimestamp).toEqual('--');
                 });
+
+                it('should support string times', function() {
+                    definition.data = [
+                        {string: 'aaa', integer: -2, mixedCase: 'Aaa', time: '2017-05-31T04:18:15.648Z', percent: 14, status: 1417455952, duration: 1234, durationToHours: 1234, durationToMilliseconds: 1234},
+                    ];
+                    table.onDataReceived(definition.data);
+
+                    expect(table.data[0].time).toEqual('2017-05-31T04:18:15.648Z');
+                    expect(table.data[0].timeTimestamp).toEqual('May 30th, 10 PM');
+                });
             });
 
             describe('status formatter', function() {


### PR DESCRIPTION
this continues the revert of the componentDidUpdate changes, which tried to bypass 're-formatting' data by ignoring times that are strings